### PR TITLE
Add some common tools for asynchronous work

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,10 @@ dependencies {
     implementation "com.google.dagger:hilt-android:$hilt_version"
     kapt "com.google.dagger:hilt-compiler:$hilt_version"
 
+    //rx java
+    implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
+    implementation 'io.reactivex.rxjava3:rxjava:3.0.0'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.4.0'
     implementation 'androidx.navigation:navigation-ui-ktx:2.4.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0'
 
     //room
     implementation "androidx.room:room-runtime:2.4.1"
@@ -66,6 +67,7 @@ dependencies {
     implementation 'io.reactivex.rxjava3:rxjava:3.0.0'
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'androidx.arch.core:core-testing:2.1.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     //retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
+    implementation 'com.squareup.retrofit2:adapter-rxjava3:2.9.0'
+
     //moshi
     implementation 'com.squareup.moshi:moshi:1.13.0'
     implementation 'com.squareup.moshi:moshi-kotlin:1.13.0'

--- a/app/src/main/java/com/kroger/start/di/NetworkModule.kt
+++ b/app/src/main/java/com/kroger/start/di/NetworkModule.kt
@@ -9,6 +9,7 @@ import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import retrofit2.Converter
 import retrofit2.Retrofit
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
 
@@ -27,10 +28,12 @@ object NetworkModule {
     @Singleton
     internal fun provideRetrofit(
         jsonConverterFactory: Converter.Factory,
-        okHttpClient: OkHttpClient
+        okHttpClient: OkHttpClient,
+        rxCallAdapter: RxJava3CallAdapterFactory,
     ): Retrofit {
         return Retrofit.Builder().baseUrl("https://xkcd.com/")
             .client(okHttpClient)
+            .addCallAdapterFactory(rxCallAdapter)
             .addConverterFactory(jsonConverterFactory)
             .build()
     }
@@ -50,5 +53,9 @@ object NetworkModule {
             .add(KotlinJsonAdapterFactory())
             .build()
     }
+
+    @Provides
+    @Singleton
+    internal fun provideRxJavaCallAdapter() = RxJava3CallAdapterFactory.create()
 
 }

--- a/app/src/main/java/com/kroger/start/di/RxSchedulersModule.kt
+++ b/app/src/main/java/com/kroger/start/di/RxSchedulersModule.kt
@@ -1,0 +1,30 @@
+package com.kroger.start.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.core.Scheduler
+import io.reactivex.rxjava3.schedulers.Schedulers
+import javax.inject.Qualifier
+
+/**
+ * A module to bind a few Rx Schedulers to the dependency graph, in case they are needed.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+class RxSchedulersModule {
+    @Provides
+    @RxMainThread
+    fun provideMainThreadScheduler(): Scheduler = AndroidSchedulers.mainThread()
+
+    @Provides
+    fun provideScheduler(): Scheduler = Schedulers.io()
+}
+
+/**
+ * A qualifier to get an Rx Scheduler that will run on the main thread.
+ */
+@Qualifier
+annotation class RxMainThread

--- a/app/src/test/java/com/kroger/start/CoroutinesTest.kt
+++ b/app/src/test/java/com/kroger/start/CoroutinesTest.kt
@@ -1,0 +1,19 @@
+package com.kroger.start
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+/**
+ * This is just a test to ensure that coroutines are on the classpath
+ */
+class CoroutinesTest {
+    @Test
+    fun testCoroutinesAvailability() {
+        runBlocking {
+            async {
+                "Coroutines"
+            }.join()
+        }
+    }
+}

--- a/app/src/test/java/com/kroger/start/LiveDataTest.kt
+++ b/app/src/test/java/com/kroger/start/LiveDataTest.kt
@@ -1,0 +1,25 @@
+package com.kroger.start
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * This is just a test that these classes are available on the classpath
+ */
+class LiveDataTest {
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Test
+    fun testLiveDataAvailability() {
+        val vm = object : ViewModel() {
+            val data = MutableLiveData("LiveData")
+        }
+        vm.data.observeForever {
+            it.length
+        }
+    }
+}

--- a/app/src/test/java/com/kroger/start/RxTest.kt
+++ b/app/src/test/java/com/kroger/start/RxTest.kt
@@ -1,0 +1,17 @@
+package com.kroger.start
+
+import io.reactivex.rxjava3.core.Observable
+import org.junit.Test
+
+/**
+ * This is just a test that these classes are available on the classpath
+ */
+class RxTest {
+    @Test
+    fun testRxAvailability() {
+        Observable.just("one", "two", "three")
+            .subscribe {
+                it.length
+            }
+    }
+}


### PR DESCRIPTION
This adds a bunch of tools, just in case candidates prefer one of them.

- RxJava3
  - Adds dependencies for RxJava3 to the classpath
  - Configures the Rx call adapter for Retrofit
  - Binds a couple `Schedulers` to the graph.
- LiveData/ViewModel
  - Includes dependency to make `viewModelScope {}`, and `liveData {}` available
- Coroutines (nothing was needed here, since all the basic stuff is already available)