### PR TITLE
Feature/lifecycle runtime compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ This is a programming skills test for potential Android developers. This project
 an app to display [XKCD comics](https://xkcd.com/). It needs the a few missing parts created to
 actually fetch and display comic images.
 
+##  Pre-interview Setup
+
+Please do all of the following before the interview:
+1. Read through this README entirely
+2. Open this project in Android Studio
+3. Install the Android SDK version used for this project (SDK level 34)
+4. Build and run the app target
+5. Look over the existing code
+
+## Your Task
+
+To begin, make a network call to get the most recent comic, and then display that comic's details
+using `ComicFragment` for an xml based view, or `ComicScreen` for a compose based view. In the UI, be sure to include:
+
+- The comic's title
+- The rendered comic image
+- The comic's alt text
+
+This screenshot shows an example of what we're going for:
+![Screenshot_1616010306](https://user-images.githubusercontent.com/51245997/111528686-d74c8780-8737-11eb-879f-e803d684d5ba.png)
+
 You may use any 3rd party tools to finish this app, but there are a number of libraries already
 included in the project for convenience. Making use of these pre-included libraries is optional:
 
@@ -50,19 +71,3 @@ Here's an example response body:
   "day": "15"
 }
 ```
-
-## Your Task
-
-To begin, make a network call to get the most recent comic, and then display that comic's details
-using `ComicFragment` for an xml based view, or `ComicScreen` for a compose based view. In the UI, be sure to include:
-
-- The comic's title
-- The rendered comic image
-- The comic's alt text
-
-This screenshot shows an example of what we're going for:
-![Screenshot_1616010306](https://user-images.githubusercontent.com/51245997/111528686-d74c8780-8737-11eb-879f-e803d684d5ba.png)
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Please do all of the following before the interview:
 3. Install the Android SDK version used for this project (SDK level 34)
 4. Build and run the app target
 5. Look over the existing code
+6. Please wait until the interview begins to start writing code
 
 ## Your Task
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-compose:2.8.1"
 
     // UI Tests
+    androidTestImplementation platform('androidx.compose:compose-bom:2022.12.00')
     androidTestImplementation "androidx.compose.ui:ui-test-junit4"
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     // Integration with observables
     implementation "androidx.compose.runtime:runtime-livedata"
     implementation "androidx.compose.runtime:runtime-rxjava2"
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.8.1"
 
     // UI Tests
     androidTestImplementation "androidx.compose.ui:ui-test-junit4"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,12 +6,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
-
     defaultConfig {
         applicationId "com.kroger.androidinterview"
+        compileSdk 34
+        targetSdkVersion 34
         minSdkVersion 22
-        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,20 +44,20 @@ dependencies {
     def lifecycle_version = "2.6.1"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0"
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.4.0'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.4.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.7.7'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.7.7'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
 
 
     /* Jetpack Compose */
-    implementation platform('androidx.compose:compose-bom:2022.12.00')
-    implementation 'androidx.activity:activity-compose:1.6.1'
+    implementation platform('androidx.compose:compose-bom:2024.05.00')
+    implementation 'androidx.activity:activity-compose:1.9.0'
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version"
     implementation "androidx.compose.ui:ui"
     // Tooling support (Previews, etc.)
@@ -75,7 +75,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-compose:2.8.1"
 
     // UI Tests
-    androidTestImplementation platform('androidx.compose:compose-bom:2022.12.00')
+    androidTestImplementation platform('androidx.compose:compose-bom:2024.05.00')
     androidTestImplementation "androidx.compose.ui:ui-test-junit4"
 
 
@@ -91,11 +91,11 @@ dependencies {
     implementation 'com.squareup.retrofit2:adapter-rxjava3:2.9.0'
 
     /* Moshi https://github.com/square/moshi */
-    implementation 'com.squareup.moshi:moshi:1.13.0'
-    implementation 'com.squareup.moshi:moshi-kotlin:1.13.0'
+    implementation 'com.squareup.moshi:moshi:1.15.0'
+    implementation 'com.squareup.moshi:moshi-kotlin:1.15.0'
 
     /* OkHttp */
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
 
     /* Dagger Hilt https://github.com/google/dagger */
     implementation "com.google.dagger:hilt-android:$hilt_version"
@@ -106,17 +106,17 @@ dependencies {
     implementation 'io.reactivex.rxjava3:rxjava:3.0.0'
 
     /* ROOM */
-    implementation "androidx.room:room-runtime:2.4.1"
-    kapt "androidx.room:room-compiler:2.4.1"
-    implementation 'androidx.room:room-ktx:2.4.1'
-    androidTestImplementation "androidx.room:room-testing:2.4.1"
+    implementation "androidx.room:room-runtime:2.6.1"
+    kapt "androidx.room:room-compiler:2.6.1"
+    implementation 'androidx.room:room-ktx:2.6.1'
+    androidTestImplementation "androidx.room:room-testing:2.6.1"
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'androidx.arch.core:core-testing:2.1.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    testImplementation 'androidx.arch.core:core-testing:2.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
-    testImplementation(platform("org.junit:junit-bom:5.9.2"))
+    testImplementation(platform("org.junit:junit-bom:5.9.3"))
     testImplementation"org.junit.jupiter:junit-jupiter"
 
     testImplementation 'app.cash.turbine:turbine:0.12.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id 'kotlin-kapt'
-    id 'dagger.hilt.android.plugin'
+    id 'com.google.devtools.ksp'
+    id 'com.google.dagger.hilt.android'
 }
 
 android {
@@ -99,7 +99,7 @@ dependencies {
 
     /* Dagger Hilt https://github.com/google/dagger */
     implementation "com.google.dagger:hilt-android:$hilt_version"
-    kapt "com.google.dagger:hilt-compiler:$hilt_version"
+    ksp "com.google.dagger:hilt-compiler:$hilt_version"
 
     /* RxAndroid and RxJava https://github.com/ReactiveX/RxAndroid */
     implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
@@ -107,7 +107,7 @@ dependencies {
 
     /* ROOM */
     implementation "androidx.room:room-runtime:2.6.1"
-    kapt "androidx.room:room-compiler:2.6.1"
+    ksp "androidx.room:room-compiler:2.6.1"
     implementation 'androidx.room:room-ktx:2.6.1'
     androidTestImplementation "androidx.room:room-testing:2.6.1"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,14 +28,14 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "1.4.1"
+        kotlinCompilerExtensionVersion "1.5.13"
     }
     namespace 'com.kroger.start'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".ComicApplication"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.kotlin_version = "1.8.0"
-    ext.hilt_version = '2.44.2'
+    ext.kotlin_version = "1.9.23"
+    ext.hilt_version = '2.51.1'
 
     repositories {
         google()
@@ -13,8 +13,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '7.4.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
+    id 'com.android.application' version '8.4.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,16 @@
 buildscript {
-    ext.kotlin_version = "1.9.23"
+    ext.kotlin_version = '1.9.23'
     ext.hilt_version = '2.51.1'
 
     repositories {
         google()
         mavenCentral()
     }
-    dependencies {
-        /* TODO: Hilt will soon publish a marker artifact, allowing this to be used from a `plugins` block */
-        classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
-    }
 }
 
 plugins {
     id 'com.android.application' version '8.4.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
-}
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
+    id 'com.google.devtools.ksp' version '1.9.23-1.0.20' apply false
+    id 'com.google.dagger.hilt.android' version "$hilt_version" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,10 +9,8 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        repositories {
-            google()
-            mavenCentral()
-        }
+        google()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
This PR upgrades basically everything in the project.

- Compile SDK 34
- Kotlin
- Dagger/Hilt
- Gradle
- AGP
- etc.

It also switches the KAPT processors over to KSP.

It adds the `lifecycle-runtime-compose` library, so that `StateFlow.collectAsStateWithLifecycle()` becomes available to use.

Lastly, it resolves a few lint warnings that failed when running `gradle build`.